### PR TITLE
fix: memory leak

### DIFF
--- a/src/resolvers/unixfs-v1/content/directory.js
+++ b/src/resolvers/unixfs-v1/content/directory.js
@@ -23,7 +23,9 @@ const directoryContent = (cid, node, unixfs, path, resolve, depth, blockstore) =
           .then(result => ({ result }))
           .catch(error => ({ error }))
       ))
-      for (const promise of resultPromises) {
+      while (true) {
+        const promise = resultPromises.shift()
+        if (!promise) return
         const res = await promise
         if ('error' in res) throw res.error
         yield res.result

--- a/src/resolvers/unixfs-v1/content/file.js
+++ b/src/resolvers/unixfs-v1/content/file.js
@@ -138,7 +138,9 @@ async function * emitAllBytes (blockstore, node, streamPosition = 0, options) {
         .then(block => ({ block }))
         .catch(error => ({ error }))
     ))
-    for (const promise of blockPromises) {
+    while (true) {
+      const promise = blockPromises.shift()
+      if (!promise) return
       const res = await promise
       if ('error' in res) throw res.error
       yield res.block


### PR DESCRIPTION
Iterating over the promises causes the runtime to retain the array, resolved promises and their value (blocks). For a "full" node there may be 174 (the default max) links, of 256k byte blocks = ~45MB of memory and for web3.storage those numbers are 1024 and 1MB = 1GB.

Retaining that much memory is not possible in a Cloudflare worker context, which have 128MB memory max. So in this PR we `shift()` the used promises off the array, allowing the runtime to GC blocks who's values got resolved.